### PR TITLE
Fix payload format version

### DIFF
--- a/src/payload/index.js
+++ b/src/payload/index.js
@@ -22,7 +22,7 @@ const SALT_BYTES = 16;
 const KDF_ROUNDS = 256;
 
 // Payload format version.
-const FORMAT_VERSION = 1;
+const FORMAT_VERSION = 3;
 
 export default class Payload {
     /**


### PR DESCRIPTION
The payload format version was incorrectly set to `1` instead of `3` (according to [spec](https://github.com/Trinkler/imagewallet/blob/master/PayloadFormat.pdf)).

This is a breaking change rendering previously generated wallet files unusable.