### PR TITLE
Remove `seed` from return of generateFromPassword function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@trinkler/imagewallet",
     "description": "A custodian file that is simpler than brainwallets and can be used for the entire blockchain ecosystem.",
-    "version": "0.5.7",
+    "version": "0.5.8",
     "author": "Trinkler Software AG <company@trinkler.software>",
     "maintainers": [
         "Reto Trinkler",

--- a/src/coins/kts.js
+++ b/src/coins/kts.js
@@ -22,6 +22,3 @@ export const symbol = 'KTS';
 
 // Elliptic curve type.
 export const curve = 'ed25519';
-
-// Hashing algorithm.
-export const hashAlgo = 'blake2b';

--- a/src/encoder/index.js
+++ b/src/encoder/index.js
@@ -27,7 +27,7 @@ const MAX_ATTEMPTS = 5;
 /**
  * Encodes an image wallet from user credentials and encoding options.
  * @param {object} credentials - Credentials to be encoded.
- * @param {string} purposeId - ???.
+ * @param {number} purposeId - A number identifying the purpose of this wallet.
  * @param {object} options - Encoding options.
  * @return An image wallet encoded as an HTMLCanvasElement.
  */
@@ -59,10 +59,7 @@ export default async function(credentials, purposeId, options) {
         // Either return or loop.
         if (wasRendered) {
             logInfo(`Canvas rendering attempt #${attempts}: success`);
-            return {
-                $canvas: ctx.$canvas,
-                seed: ctx.seed
-            };
+            return { $canvas: ctx.$canvas };
         } else {
             logWarning(`Canvas rendering attempt #${attempts}: failed`);
             ctx = new EncodingContextInfo(credentials, options);
@@ -70,7 +67,7 @@ export default async function(credentials, purposeId, options) {
     } while (attempts < MAX_ATTEMPTS);
 
     // If not rendered then throw error.
-    throw new Error("Image wallet rendering failed");
+    throw new Error('Image wallet rendering failed');
 }
 
 /**
@@ -79,7 +76,7 @@ export default async function(credentials, purposeId, options) {
  */
 const validateInputs = (credentials, options) => {
     logTODO(`validate password [${credentials.password}] minimum length = 8 ?`);
-}
+};
 
 /**
  * Contextual information passed along encoding pipeline.

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
  * @fileOverview An image wallet - easier than brain wallets.
  *
  * @exports decode/deriveKey/encode/name/provider/version
- * @version 0.5.7
+ * @version 0.5.8
  */
 
 // Module imports.
@@ -16,12 +16,12 @@ import decodeQR from './decoder/decodeQR';
 import decryptQR from './decoder/decryptQR';
 import generateEntropy from './cryptography/entropyCreation';
 import keyDeriver from './cryptography/keyDerivation/derive';
-import {ed25519} from './cryptography/ecc/index';
+import { ed25519 } from './cryptography/ecc/index';
 import encoder from './encoder/index';
-import {arrayToHex} from './utils/conversion';
+import { arrayToHex } from './utils/conversion';
 import blake2b from './cryptography/hashing/blake2b';
 import keccak256 from './cryptography/hashing/keccak256';
-import {NotImplementedError} from './utils/exceptions';
+import { NotImplementedError } from './utils/exceptions';
 import * as testUtils from './utils/testing';
 
 // Library version.
@@ -31,7 +31,7 @@ const name = 'Imagewallet';
 const provider = 'Trinkler Software AG';
 
 // Library version.
-const version = '0.5.7';
+const version = '0.5.8';
 
 /**
  * Returns a 32 byte PRNG seed.
@@ -42,7 +42,7 @@ const createSeed = (encoding) => {
     const seed = generateEntropy();
 
     return encoding == 'hex' ? seed.toString('hex') : seed;
-}
+};
 
 /**
  * Asynchronously decrypts an image wallet.
@@ -69,7 +69,7 @@ const decryptQrData = async (qrData, password) => {
 };
 
 /**
-* Returns a key pair derived from a seed over which a derivation path algorithm is applied.
+ * Returns a key pair derived from a seed over which a derivation path algorithm is applied.
  *
  * @param {hex} seed - Master source of entropy.
  * @param {string} coinSymbol - Coin symbol, e.g. IW.
@@ -84,10 +84,10 @@ const deriveKeyPair = (seed, coinSymbol, accountIndex) => {
     kp.pvk = kp.privateKey;
 
     return kp;
-}
+};
 
 /**
-* Returns a private key derived from a seed over which a derivation path algorithm is applied.
+ * Returns a private key derived from a seed over which a derivation path algorithm is applied.
  *
  * @param {hex} seed - Master source of entropy.
  * @param {string} coinSymbol - Coin symbol, e.g. IW.
@@ -98,7 +98,7 @@ const derivePrivateKey = (seed, coinSymbol, accountIndex) => {
     const kp = deriveKeyPair(seed, coinSymbol, accountIndex);
 
     return kp.privateKey;
-}
+};
 
 // Synonym.
 const deriveKey = derivePrivateKey;
@@ -112,7 +112,7 @@ const deriveKey = derivePrivateKey;
  * @return A promise resolving to an HTML canvas object.
  */
 const generateFromPassword = async (password, purposeId, options) => {
-    return await encoder({password}, purposeId, options);
+    return await encoder({ password }, purposeId, options);
 };
 
 /**
@@ -135,7 +135,7 @@ const getHash = (data, encoding) => {
     // TODO validate input
     const input = JSON.stringify(data);
     return blake2b(input, encoding || 'hex');
-}
+};
 
 /**
  * Returns a user's private key.
@@ -145,7 +145,7 @@ const getHash = (data, encoding) => {
 const getUserPrivateKey = (derivedEntropy) => {
     // TODO validate input
     return arrayToHex(ed25519.getPrivateKey(derivedEntropy));
-}
+};
 
 /**
  * Returns a user's public key.
@@ -155,7 +155,7 @@ const getUserPrivateKey = (derivedEntropy) => {
 const getUserPublicKey = (pvk) => {
     // TODO validate input
     return arrayToHex(ed25519.getPublicKey(pvk));
-}
+};
 
 /**
  * Signs a data structure.
@@ -170,7 +170,7 @@ const signData = (pvk, data, encoding) => {
 
     const sig = signHash(pvk, msgHash, encoding);
 
-    return {sig, msgHash};
+    return { sig, msgHash };
 };
 
 /**
@@ -213,7 +213,7 @@ const verifyHash = (pbk, msgHash, sig) => {
 export {
     // ... meta-data
     name,
-	provider,
+    provider,
     version,
     // ... image file management
     decryptImage,

--- a/test/000.interface.test.js
+++ b/test/000.interface.test.js
@@ -22,8 +22,8 @@ test('IW :: interface :: is defined', () => {
         'signHash',
         'verifyData',
         'verifyHash',
-	]);
+    ]);
     expect(IW.name).toBe('Imagewallet');
-    expect(IW.version).toBe('0.5.7');
+    expect(IW.version).toBe('0.5.8');
     expect(IW.provider).toBe('Trinkler Software AG');
 });


### PR DESCRIPTION
Version bump

Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

### Deprecated

### Removed

- Remove `seed` from return of generateFromPassword function

### Fixed

### Security
